### PR TITLE
v0.2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ available settings.
 
 This is a personal project aimed at making the task of setting up a Mac more
 straightforward. Contributions are always welcome! Feel free to help out by
-[creating a pull request]() or [submitting an issue]().
+[creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) or [submitting an issue](https://github.com/hitblast/cutler/issues).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Declarative macOS settings management at your fingertips, with speed. <br>
 
 </div>
 
-## 🍺 Installation 
+## 🍺 Installation
 
 Install cutler using [Homebrew](https://brew.sh) by simply running:
 
@@ -143,10 +143,14 @@ To revert all modifications, run:
 cutler unapply
 ```
 
-And if you decide to completely revert everything to factory defaults, run:
+Now, when it comes to managing the configuration file itself, there is a `config` command which has two other subcommands:
 
 ```bash
-cutler delete
+# Shows the contents of the configuration file.
+cutler config show
+
+# Unapplies and deletes the configuration file.
+cutler config delete
 ```
 
 You can add `--verbose` for more detail on what happens behind the scenes. For

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ brew install hitblast/tap/cutler
 ## Table of Contents
 
 - [Overview](#overview)
-- [Installation Methods](#other-installation-methods)
+- [Other Installation Methods](#other-installation-methods)
 - [Usage](#usage)
 - [Resources](#resources)
 - [Notable things](#notable-things)
@@ -45,7 +45,7 @@ can quickly apply or undo settings when needed.
 
 Check out the [Usage](#usage) section for more details.
 
-## Installation Methods
+## Other Installation Methods
 
 Besides using Homebrew as shown above, you can install the project in a couple of other ways:
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -11,7 +11,7 @@ use crate::domains::{collect_domains, get_effective_domain_and_key};
 use crate::logging::{print_log, LogLevel};
 
 /// Applies settings from the configuration file.
-pub fn apply_defaults(verbose: bool) -> Result<(), Box<dyn std::error::Error>> {
+pub fn apply_defaults(verbose: bool, dry_run: bool) -> Result<(), Box<dyn std::error::Error>> {
     let config_path = get_config_path();
 
     if !config_path.exists() {
@@ -54,24 +54,42 @@ pub fn apply_defaults(verbose: bool) -> Result<(), Box<dyn std::error::Error>> {
                 continue;
             }
             let (flag, value_str) = get_flag_and_value(value)?;
-            execute_defaults_write(&eff_domain, &eff_key, flag, &value_str, "Applying", verbose)?;
+            execute_defaults_write(
+                &eff_domain,
+                &eff_key,
+                flag,
+                &value_str,
+                "Applying",
+                verbose,
+                dry_run,
+            )?;
         }
     }
 
+    // Copying the snapshot file
     let snapshot_path = get_snapshot_path();
-    fs::copy(&config_path, &snapshot_path)?;
-
-    if verbose {
+    if dry_run {
         print_log(
-            LogLevel::Success,
-            &format!("Snapshot updated at {:?}", snapshot_path),
+            LogLevel::Info,
+            &format!(
+                "Dry-run: Would copy config file from {:?} to {:?}",
+                config_path, snapshot_path
+            ),
         );
+    } else {
+        fs::copy(&config_path, &snapshot_path)?;
+        if verbose {
+            print_log(
+                LogLevel::Success,
+                &format!("Snapshot updated at {:?}", snapshot_path),
+            );
+        }
     }
     Ok(())
 }
 
 /// Unapplies settings using the stored snapshot.
-pub fn unapply_defaults(verbose: bool) -> Result<(), Box<dyn std::error::Error>> {
+pub fn unapply_defaults(verbose: bool, dry_run: bool) -> Result<(), Box<dyn std::error::Error>> {
     let snapshot_path = get_snapshot_path();
     if !snapshot_path.exists() {
         return Err("No snapshot found. Please apply settings first before unapplying.".into());
@@ -119,23 +137,29 @@ pub fn unapply_defaults(verbose: bool) -> Result<(), Box<dyn std::error::Error>>
             } else {
                 continue;
             }
-            execute_defaults_delete(&eff_domain, &eff_key, "Unapplying", verbose)?;
+            execute_defaults_delete(&eff_domain, &eff_key, "Unapplying", verbose, dry_run)?;
         }
     }
 
-    fs::remove_file(&snapshot_path)?;
-
-    if verbose {
+    if dry_run {
         print_log(
-            LogLevel::Success,
-            &format!("Snapshot removed from {:?}", snapshot_path),
+            LogLevel::Info,
+            &format!("Dry-run: Would remove snapshot file at {:?}", snapshot_path),
         );
+    } else {
+        fs::remove_file(&snapshot_path)?;
+        if verbose {
+            print_log(
+                LogLevel::Success,
+                &format!("Snapshot removed from {:?}", snapshot_path),
+            );
+        }
     }
     Ok(())
 }
 
 /// Deletes the configuration file and offers to unapply settings if they are still active.
-pub fn delete_config(verbose: bool) -> Result<(), Box<dyn std::error::Error>> {
+pub fn delete_config(verbose: bool, dry_run: bool) -> Result<(), Box<dyn std::error::Error>> {
     let config_path = get_config_path();
     if !config_path.exists() {
         if verbose {
@@ -143,8 +167,8 @@ pub fn delete_config(verbose: bool) -> Result<(), Box<dyn std::error::Error>> {
                 LogLevel::Success,
                 &format!("No configuration file found at: {:?}", config_path),
             );
-            return Ok(());
         }
+        return Ok(());
     }
 
     let current_parsed = load_config(&config_path)?;
@@ -180,41 +204,71 @@ pub fn delete_config(verbose: bool) -> Result<(), Box<dyn std::error::Error>> {
         io::stdin().read_line(&mut input)?;
 
         if input.trim().eq_ignore_ascii_case("y") {
-            unapply_defaults(verbose)?;
+            unapply_defaults(verbose, dry_run)?;
         }
     }
 
-    fs::remove_file(&config_path)?;
-
-    if verbose {
+    if dry_run {
         print_log(
-            LogLevel::Success,
-            &format!("Configuration file deleted from: {:?}", config_path),
+            LogLevel::Info,
+            &format!(
+                "Dry-run: Would remove configuration file at {:?}",
+                config_path
+            ),
         );
+    } else {
+        fs::remove_file(&config_path)?;
+        if verbose {
+            print_log(
+                LogLevel::Success,
+                &format!("Configuration file deleted from: {:?}", config_path),
+            );
+        }
     }
 
     let snapshot_path = get_snapshot_path();
     if snapshot_path.exists() {
-        fs::remove_file(&snapshot_path)?;
+        if dry_run {
+            print_log(
+                LogLevel::Info,
+                &format!("Dry-run: Would remove snapshot file at {:?}", snapshot_path),
+            );
+        } else {
+            fs::remove_file(&snapshot_path)?;
+        }
     }
     Ok(())
 }
 
 /// Kills (restarts) Finder, Dock, and SystemUIServer to refresh settings.
-pub fn restart_system_services(verbose: bool) -> Result<(), Box<dyn std::error::Error>> {
+pub fn restart_system_services(
+    verbose: bool,
+    dry_run: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
     for service in &["Finder", "Dock", "SystemUIServer"] {
-        let output = Command::new("killall").arg(service).output()?;
-        if !output.status.success() {
-            print_log(
-                LogLevel::Error,
-                &format!("Failed to restart {}, try restarting manually.", service),
-            );
-        } else if verbose {
-            print_log(LogLevel::Success, &format!("{} restarted.", service));
+        if dry_run {
+            if verbose {
+                print_log(
+                    LogLevel::Info,
+                    &format!("Dry-run: Would restart {}", service),
+                );
+            }
+        } else {
+            let output = Command::new("killall").arg(service).output()?;
+            if !output.status.success() {
+                print_log(
+                    LogLevel::Error,
+                    &format!("Failed to restart {}, try restarting manually.", service),
+                );
+            } else if verbose {
+                print_log(LogLevel::Success, &format!("{} restarted.", service));
+            }
         }
     }
-    if !verbose {
+    if !verbose && !dry_run {
         println!("\n🍎 Done. System services restarted.");
+    } else if dry_run {
+        println!("\n🍎 Dry-run: System services would be restarted.");
     }
     Ok(())
 }
@@ -242,12 +296,10 @@ pub fn status_defaults(verbose: bool) -> Result<(), Box<dyn std::error::Error>> 
                 get_current_value(&eff_domain, &eff_key).unwrap_or_else(|| "Not set".into());
             if verbose {
                 let mut color = crate::logging::GREEN;
-
                 if current != desired {
                     any_changed = true;
                     color = crate::logging::RED;
                 }
-
                 println!(
                     "{}{} {} -> {} (now {}){}",
                     color,

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -24,7 +24,18 @@ pub fn execute_defaults_write(
     value_str: &str,
     action: &str,
     verbose: bool,
+    dry_run: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    if dry_run {
+        print_log(
+            LogLevel::Info,
+            &format!(
+                "Dry-run: Would execute: defaults write {} \"{}\" {} \"{}\"",
+                eff_domain, eff_key, flag, value_str
+            ),
+        );
+        return Ok(());
+    }
     if verbose {
         print_log(
             LogLevel::Info,
@@ -66,7 +77,18 @@ pub fn execute_defaults_delete(
     eff_key: &str,
     action: &str,
     verbose: bool,
+    dry_run: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    if dry_run {
+        print_log(
+            LogLevel::Info,
+            &format!(
+                "Dry-run: Would execute: defaults delete {} \"{}\"",
+                eff_domain, eff_key
+            ),
+        );
+        return Ok(());
+    }
     if verbose {
         print_log(
             LogLevel::Info,

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -3,6 +3,7 @@ pub const RED: &str = "\x1b[31m";
 pub const GREEN: &str = "\x1b[32m";
 pub const YELLOW: &str = "\x1b[33m";
 pub const RESET: &str = "\x1b[0m";
+pub const BOLD: &str = "\x1b[1m";
 
 /// Log levels for printing messages.
 #[derive(PartialEq)]
@@ -19,6 +20,6 @@ pub fn print_log(level: LogLevel, message: &str) {
         LogLevel::Success => println!("{}[SUCCESS]{} {}", GREEN, RESET, message),
         LogLevel::Error => eprintln!("{}[ERROR]{} {}", RED, RESET, message),
         LogLevel::Warning => eprintln!("{}[WARN]{} {}", YELLOW, RESET, message),
-        LogLevel::Info => println!("[INFO] {}", message),
+        LogLevel::Info => println!("{}[INFO]{} {}", BOLD, RESET, message),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
 use clap::{Parser, Subcommand};
 use cutler::{
     commands::{
-        apply_defaults, delete_config, restart_system_services, status_defaults, unapply_defaults,
+        apply_defaults, config_delete, config_show, restart_system_services, status_defaults,
+        unapply_defaults,
     },
-    logging::{print_log, LogLevel, RED, RESET},
+    logging::{print_log, LogLevel},
 };
 
 /// Declarative macOS settings management at your fingertips, with speed.
@@ -28,33 +29,50 @@ enum Commands {
     Apply,
     /// Unapply (delete) defaults from the config file.
     Unapply,
-    /// Delete the configuration file.
-    Delete,
     /// Display current status comparing the config vs current defaults.
     Status,
+    /// Manage the configuration file.
+    Config {
+        #[command(subcommand)]
+        command: ConfigCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum ConfigCommand {
+    /// Display the contents of the configuration file.
+    Show,
+    /// Delete the configuration file.
+    Delete,
 }
 
 fn main() {
     let cli = Cli::parse();
 
-    // For commands that make modifications, pass both the verbose and dry_run flags.
     let result = match &cli.command {
         Commands::Apply => apply_defaults(cli.verbose, cli.dry_run),
         Commands::Unapply => unapply_defaults(cli.verbose, cli.dry_run),
-        Commands::Delete => delete_config(cli.verbose, cli.dry_run),
         Commands::Status => status_defaults(cli.verbose),
+        Commands::Config { command } => match command {
+            ConfigCommand::Show => config_show(cli.verbose, cli.dry_run),
+            ConfigCommand::Delete => config_delete(cli.verbose, cli.dry_run),
+        },
     };
 
     match result {
         Ok(_) => {
-            // Restart system services for commands that modify defaults
+            // For commands that modify defaults, restart system services.
             match &cli.command {
-                Commands::Apply | Commands::Unapply | Commands::Delete => {
+                Commands::Apply
+                | Commands::Unapply
+                | Commands::Config {
+                    command: ConfigCommand::Delete,
+                } => {
                     if let Err(e) = restart_system_services(cli.verbose, cli.dry_run) {
-                        eprintln!("{}[ERROR]{} Failed to restart services: {}", RED, RESET, e);
+                        eprintln!("🍎 Manual restart might be required: {}", e);
                     }
                 }
-                Commands::Status => {}
+                _ => {}
             }
         }
         Err(e) => {


### PR DESCRIPTION
## ✨ Covered Features

New entries will be added with the progress of the pull request.

- [x] Add `--dry-run` flag for change demonstration for commands.
- [x] Add new `config` command:
    - [x] Integrate the existing `delete` command as a subcommand so that it becomes harder by design to accidentally delete the configuration file.
    - [x] Add a new `show` subcommand which returns the configuration to standard output.
