### PR TITLE
(feat) `[external]` replaced by `[commands]` and `[vars]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cutler"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2024"
 description = "Powerful, declarative settings management for your Mac, with speed."
 license = "MIT"

--- a/landing/index.html
+++ b/landing/index.html
@@ -418,8 +418,7 @@ cutler config delete</code></pre>
             custom commands to be executed:
         </p>
 
-        <pre><code class="language-bash">[external]
-[commands.greet]
+        <pre><code class="language-bash">[commands.greet]
   cmd = "echo \"Hello World\""</code></pre>
 
         <p>This translates to running:</p>
@@ -431,12 +430,12 @@ cutler config delete</code></pre>
         </p>
         <pre><code class="language-bash"># Define reusable variables here:
 [vars]
-  common_args = ["Hello", "World"]
-  some_string = "Pancakes!"
+common_args = ["Hello", "World"]
+some_string = "Pancakes!"
 
 [commands.greet]
-  run = "echo $common_args"
-  sudo = false</code></pre>
+run = "echo $common_args"
+sudo = false</code></pre>
 
         <h2>Some Personal Take</h2>
         <hr />

--- a/landing/index.html
+++ b/landing/index.html
@@ -419,7 +419,7 @@ cutler config delete</code></pre>
         </p>
 
         <pre><code class="language-bash">[external]
-  [[external.command]]
+[commands.greet]
   cmd = "echo \"Hello World\""</code></pre>
 
         <p>This translates to running:</p>
@@ -432,13 +432,11 @@ cutler config delete</code></pre>
         <pre><code class="language-bash"># Define reusable variables here:
 [vars]
   common_args = ["Hello", "World"]
+  some_string = "Pancakes!"
 
 [commands.greet]
   run = "echo $common_args"
   sudo = false</code></pre>
-
-        <p>This roughly translates to:</p>
-        <pre><code class="language-bash">echo Hello World</code></pre>
 
         <h2>Some Personal Take</h2>
         <hr />

--- a/landing/index.html
+++ b/landing/index.html
@@ -410,7 +410,7 @@ cutler config delete</code></pre>
             </p>
         </div>
 
-        <h2>Advanced Features</h2>
+        <h2>Custom Commands</h2>
         <hr />
 
         <p>
@@ -430,20 +430,15 @@ cutler config delete</code></pre>
             with separate arguments and variables:
         </p>
         <pre><code class="language-bash"># Define reusable variables here:
-[external.variables]
-common_args = ["Hello", "World"]
+[vars]
+  common_args = ["Hello", "World"]
 
-[external]
-  [[external.command]]
-  cmd = "echo"
-  # If you reference a variable (for example, $common_args) and it isn't defined
-  # in the [external.variables] section, cutler will fall back and try to resolve it
-  # from the environment (e.g. $PATH).
-  args = ["$common_args", "$PATH"]
+[commands.greet]
+  run = "echo $common_args"
   sudo = false</code></pre>
 
         <p>This roughly translates to:</p>
-        <pre><code class="language-bash">echo Hello World /usr/local/bin:/usr/bin:...</code></pre>
+        <pre><code class="language-bash">echo Hello World</code></pre>
 
         <h2>Some Personal Take</h2>
         <hr />

--- a/landing/index.html
+++ b/landing/index.html
@@ -311,19 +311,9 @@ mise use -g cargo:cutler</code></pre>
             >
             to get started quickly!
         </p>
-        <pre><code class="language-bash">[dock]
-tilesize = 46
-
-[finder]
-AppleShowAllFiles = true
-CreateDesktop = false
-
-[NSGlobalDomain]
-ApplePressAndHoldEnabled = true</code></pre>
-
         <p>
-            Or, to setup a comprehensive example on your Mac automatically, use
-            this command:
+            In order to setup a comprehensive example on your Mac automatically,
+            use this command:
         </p>
         <pre><code class="language-bash">cutler init</code></pre>
 
@@ -418,8 +408,9 @@ cutler config delete</code></pre>
             custom commands to be executed:
         </p>
 
-        <pre><code class="language-bash">[commands.greet]
-  cmd = "echo \"Hello World\""</code></pre>
+        <pre><code class="language-bash"># A basic hello
+[commands.greet]
+cmd = "echo \"Hello World\""</code></pre>
 
         <p>This translates to running:</p>
         <pre><code class="language-bash">echo "Hello World"</code></pre>
@@ -436,6 +427,13 @@ some_string = "Pancakes!"
 [commands.greet]
 run = "echo $common_args"
 sudo = false</code></pre>
+
+        <p>If you want to run them:</p>
+        <pre><code class="language-bash"># combined execution
+cutler exec
+
+# or
+cutler exec greet</code></pre>
 
         <h2>Some Personal Take</h2>
         <hr />

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -31,7 +31,11 @@ pub enum Command {
         no_exec: bool,
     },
     /// Run only the external commands written in the config file.
-    Exec,
+    Exec {
+        /// Provide a command name to execute if you only want to run it specifically.
+        #[arg(value_name = "NAME")]
+        name: Option<String>,
+    },
     /// Initialize a new config file with sensible defaults.
     Init {
         /// Skip confirmation prompt.

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -145,7 +145,7 @@ pub fn run(no_exec: bool, verbose: bool, dry_run: bool) -> Result<()> {
             new_value: job.new_value,
         });
     }
-    new_snap.external = runner::extract(&toml);
+    new_snap.commands = runner::extract(&toml);
 
     if !dry_run {
         new_snap.save(&snap_path)?;

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -161,10 +161,6 @@ pub fn run(no_exec: bool, verbose: bool, dry_run: bool) -> Result<()> {
 
     // exec external commands
     if !no_exec {
-        print_log(
-            LogLevel::Warning,
-            "External commands will have a restructuring in version v0.5.5.",
-        );
         let _ = runner::run_all(&toml, verbose, dry_run);
     }
 

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -145,7 +145,7 @@ pub fn run(no_exec: bool, verbose: bool, dry_run: bool) -> Result<()> {
             new_value: job.new_value,
         });
     }
-    new_snap.commands = runner::extract(&toml);
+    new_snap.external = runner::extract(&toml);
 
     if !dry_run {
         new_snap.save(&snap_path)?;

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -55,7 +55,7 @@ pub fn run(which: Option<String>, verbose: bool, dry_run: bool) -> Result<()> {
     );
 
     // record external commands into the snapshot
-    snapshot.commands = runner::extract(&toml);
+    snapshot.external = runner::extract(&toml);
 
     // save the snapshot before executing
     if dry_run {

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use anyhow::Result;
 
-pub fn run(verbose: bool, dry_run: bool) -> Result<()> {
+pub fn run(which: Option<String>, verbose: bool, dry_run: bool) -> Result<()> {
     let config_path = get_config_path();
     if !config_path.exists() {
         print_log(
@@ -55,7 +55,7 @@ pub fn run(verbose: bool, dry_run: bool) -> Result<()> {
     );
 
     // record external commands into the snapshot
-    snapshot.external = runner::extract(&toml);
+    snapshot.commands = runner::extract(&toml);
 
     // save the snapshot before executing
     if dry_run {
@@ -73,8 +73,11 @@ pub fn run(verbose: bool, dry_run: bool) -> Result<()> {
         }
     }
 
-    // run external commands
-    runner::run_all(&toml, verbose, dry_run)?;
+    if let Some(cmd_name) = which {
+        runner::run_one(&toml, &cmd_name, verbose, dry_run)?;
+    } else {
+        runner::run_all(&toml, verbose, dry_run)?;
+    }
 
     if !verbose && !dry_run {
         println!("\n🍎 External commands executed successfully.");

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -64,13 +64,11 @@ expose-group-apps    = true
 fnState = false
 
 # External commands (uncomment / customize as needed)
-# [external.variables]
+# [vars]
 # hostname = "my-macbook"
-
-# [external]
-# [[external.command]]
-# cmd  = "scutil"
-# args = ["--set", "ComputerName", "$hostname"]
+# 
+# [commands.hostname]
+# cmd  = "scutil --set ComputerName $hostname"
 # sudo = true
 "#;
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -15,7 +15,7 @@ use anyhow::Result;
 pub fn dispatch(command: &Command, verbose: bool, dry_run: bool, no_restart: bool) -> Result<()> {
     let result = match command {
         Command::Apply { no_exec } => apply::run(*no_exec, verbose, dry_run),
-        Command::Exec => exec::run(verbose, dry_run),
+        Command::Exec { name } => exec::run(name.clone(), verbose, dry_run),
         Command::Init { force } => init::run(verbose, *force),
         Command::Unapply => unapply::run(verbose, dry_run),
         Command::Reset { force } => reset::run(verbose, dry_run, *force),

--- a/src/commands/unapply.rs
+++ b/src/commands/unapply.rs
@@ -69,7 +69,7 @@ pub fn run(verbose: bool, dry_run: bool) -> Result<()> {
     });
 
     // warn about external commands (not automatically reverted)
-    if !snapshot.commands.is_empty() {
+    if !snapshot.external.is_empty() {
         print_log(
             LogLevel::Warning,
             "External commands were executed previously; please revert them manually if needed.",

--- a/src/commands/unapply.rs
+++ b/src/commands/unapply.rs
@@ -69,7 +69,7 @@ pub fn run(verbose: bool, dry_run: bool) -> Result<()> {
     });
 
     // warn about external commands (not automatically reverted)
-    if !snapshot.external.is_empty() {
+    if !snapshot.commands.is_empty() {
         print_log(
             LogLevel::Warning,
             "External commands were executed previously; please revert them manually if needed.",

--- a/src/domains/collector.rs
+++ b/src/domains/collector.rs
@@ -46,7 +46,7 @@ pub fn collect(parsed: &Value) -> Result<HashMap<String, toml::value::Table>, an
     let mut out = HashMap::new();
 
     for (key, val) in root {
-        if key == "external" {
+        if key == "commands" || key == "vars" {
             continue;
         }
         if let Value::Table(inner) = val {

--- a/src/domains/collector.rs
+++ b/src/domains/collector.rs
@@ -4,6 +4,8 @@ use std::process::Command;
 use std::sync::{Mutex, Once};
 use toml::Value;
 
+use crate::util::logging::{LogLevel, print_log};
+
 lazy_static! {
     // Cache of “defaults domains” returned by `defaults domains`
     static ref DOMAIN_CACHE: Mutex<Option<HashSet<String>>> = Mutex::new(None);
@@ -48,7 +50,13 @@ pub fn collect(parsed: &Value) -> Result<HashMap<String, toml::value::Table>, an
     for (key, val) in root {
         if key == "commands" || key == "vars" {
             continue;
+        } else if key == "external" {
+            print_log(
+                LogLevel::Warning,
+                "[external] has been deprecated in version v0.5.5 and won't be executed.\n\n Please visit https://hitblast.github.io/cutler for more information regarding the new way of declaring external commands.",
+            );
         }
+
         if let Value::Table(inner) = val {
             let mut flat = Vec::with_capacity(inner.len());
             flatten_domains(Some(key.clone()), inner, &mut flat);

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -1,2 +1,2 @@
 pub mod state;
-pub use state::{ExternalCommandState, SettingState, Snapshot, get_snapshot_path};
+pub use state::{Snapshot, get_snapshot_path};

--- a/src/snapshot/state.rs
+++ b/src/snapshot/state.rs
@@ -13,8 +13,7 @@ pub struct SettingState {
 /// One external command run.
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct ExternalCommandState {
-    pub cmd: String,
-    pub args: Vec<String>,
+    pub run: String,
     pub sudo: bool,
 }
 
@@ -22,7 +21,7 @@ pub struct ExternalCommandState {
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct Snapshot {
     pub settings: Vec<SettingState>,
-    pub external: Vec<ExternalCommandState>,
+    pub commands: Vec<ExternalCommandState>,
     pub version: String,
 }
 
@@ -30,7 +29,7 @@ impl Snapshot {
     pub fn new() -> Self {
         Snapshot {
             settings: Vec::new(),
-            external: Vec::new(),
+            commands: Vec::new(),
             version: env!("CARGO_PKG_VERSION").into(),
         }
     }

--- a/src/snapshot/state.rs
+++ b/src/snapshot/state.rs
@@ -21,7 +21,7 @@ pub struct ExternalCommandState {
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct Snapshot {
     pub settings: Vec<SettingState>,
-    pub commands: Vec<ExternalCommandState>,
+    pub external: Vec<ExternalCommandState>,
     pub version: String,
 }
 
@@ -29,7 +29,7 @@ impl Snapshot {
     pub fn new() -> Self {
         Snapshot {
             settings: Vec::new(),
-            commands: Vec::new(),
+            external: Vec::new(),
             version: env!("CARGO_PKG_VERSION").into(),
         }
     }

--- a/tests/external_test.rs
+++ b/tests/external_test.rs
@@ -1,34 +1,56 @@
 #[cfg(test)]
 mod tests {
-    use cutler::external::run_all;
+    use cutler::external::runner::{run_all, run_one};
     use toml::{Value, value::Table};
 
     #[test]
     fn test_run_all_dry_run() {
+        // Build a [vars] table
         let mut vars = Table::new();
         vars.insert("hostname".into(), Value::String("test-host".into()));
 
+        // Build a [commands.foo] table
         let mut cmd = Table::new();
-        cmd.insert("cmd".into(), Value::String("echo".into()));
-        cmd.insert(
-            "args".into(),
-            Value::Array(vec![
-                Value::String("Hello".into()),
-                Value::String("$hostname".into()),
-            ]),
+        cmd.insert("run".into(), Value::String("echo Hello $hostname".into()));
+        // sudo is optional; default is false
+        let mut commands = Table::new();
+        commands.insert("foo".into(), Value::Table(cmd));
+
+        // Top‐level config = { vars = {...}, commands = { foo = { … } } }
+        let mut root = Table::new();
+        root.insert("vars".into(), Value::Table(vars));
+        root.insert("commands".into(), Value::Table(commands));
+        let config = Value::Table(root);
+
+        // Dry‑run should always succeed
+        assert!(run_all(&config, /*verbose=*/ true, /*dry_run=*/ true).is_ok());
+    }
+
+    #[test]
+    fn test_run_one_dry_run() {
+        // Very similar setup
+        let mut vars = Table::new();
+        vars.insert("USER".into(), Value::String("me".into()));
+
+        let mut cmd = Table::new();
+        cmd.insert("run".into(), Value::String("echo $USER".into()));
+        // mark it sudo=true to exercise that branch
+        cmd.insert("sudo".into(), Value::Boolean(true));
+
+        let mut commands = Table::new();
+        commands.insert("whoami".into(), Value::Table(cmd));
+
+        let mut root = Table::new();
+        root.insert("vars".into(), Value::Table(vars));
+        root.insert("commands".into(), Value::Table(commands));
+        let config = Value::Table(root);
+
+        // Dry‑run single command
+        assert!(
+            run_one(
+                &config, "whoami", /*verbose=*/ true, /*dry_run=*/ true
+            )
+            .is_ok()
         );
-
-        let mut ext = Table::new();
-        ext.insert("variables".into(), Value::Table(vars));
-        ext.insert("command".into(), Value::Array(vec![Value::Table(cmd)]));
-
-        let config = Value::Table({
-            let mut m = Table::new();
-            m.insert("external".into(), Value::Table(ext));
-            m
-        });
-
-        // Should succeed in dry‐run
-        assert!(run_all(&config, true, true).is_ok());
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -81,7 +81,7 @@ mod tests {
         });
 
         // Add an external command
-        snapshot.commands.push(ExternalCommandState {
+        snapshot.external.push(ExternalCommandState {
             run: "echo \"Hello, World!\"".to_string(),
             sudo: false,
         });
@@ -118,7 +118,7 @@ mod tests {
         }
 
         // 3. Verify external commands are tracked correctly
-        assert_eq!(loaded_snapshot.commands.len(), 1);
-        assert_eq!(loaded_snapshot.commands[0].run, "echo \"Hello, World!\"");
+        assert_eq!(loaded_snapshot.external.len(), 1);
+        assert_eq!(loaded_snapshot.external[0].run, "echo \"Hello, World!\"");
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -59,7 +59,7 @@ mod tests {
     #[test]
     fn test_snapshot_integration() {
         use cutler::defaults::from_flag;
-        use cutler::snapshot::{ExternalCommandState, SettingState, Snapshot};
+        use cutler::snapshot::state::{ExternalCommandState, SettingState, Snapshot};
         use tempfile::TempDir;
 
         // Create a sample snapshot
@@ -81,9 +81,8 @@ mod tests {
         });
 
         // Add an external command
-        snapshot.external.push(ExternalCommandState {
-            cmd: "echo".to_string(),
-            args: vec!["Hello".to_string()],
+        snapshot.commands.push(ExternalCommandState {
+            run: "echo \"Hello, World!\"".to_string(),
             sudo: false,
         });
 
@@ -119,7 +118,7 @@ mod tests {
         }
 
         // 3. Verify external commands are tracked correctly
-        assert_eq!(loaded_snapshot.external.len(), 1);
-        assert_eq!(loaded_snapshot.external[0].cmd, "echo");
+        assert_eq!(loaded_snapshot.commands.len(), 1);
+        assert_eq!(loaded_snapshot.commands[0].run, "echo \"Hello, World!\"");
     }
 }

--- a/tests/snapshot_test.rs
+++ b/tests/snapshot_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use cutler::snapshot::{ExternalCommandState, SettingState, Snapshot, get_snapshot_path};
+    use cutler::snapshot::state::{ExternalCommandState, SettingState, Snapshot, get_snapshot_path};
     use std::collections::HashMap;
     use std::path::PathBuf;
     use std::{env, fs};
@@ -31,7 +31,7 @@ mod tests {
         // Test creation
         let snapshot = Snapshot::new();
         assert_eq!(snapshot.settings.len(), 0);
-        assert_eq!(snapshot.external.len(), 0);
+        assert_eq!(snapshot.commands.len(), 0);
         assert_eq!(snapshot.version, env!("CARGO_PKG_VERSION"));
 
         // Test setting state
@@ -48,12 +48,10 @@ mod tests {
 
         // Test external command state
         let command = ExternalCommandState {
-            cmd: "echo".to_string(),
-            args: vec!["Hello".to_string(), "World".to_string()],
+            run: "echo Hello World".to_string(),
             sudo: false,
         };
-        assert_eq!(command.cmd, "echo");
-        assert_eq!(command.args, vec!["Hello".to_string(), "World".to_string()]);
+        assert_eq!(command.run, "echo Hello World");
         assert_eq!(command.sudo, false);
     }
 
@@ -85,15 +83,13 @@ mod tests {
         });
 
         // Add multiple external commands
-        snapshot.external.push(ExternalCommandState {
-            cmd: "echo".to_string(),
-            args: vec!["Hello".to_string()],
+        snapshot.commands.push(ExternalCommandState {
+            run: "echo Hello".to_string(),
             sudo: false,
         });
 
-        snapshot.external.push(ExternalCommandState {
-            cmd: "hostname".to_string(),
-            args: vec!["-s".to_string(), "macbook".to_string()],
+        snapshot.commands.push(ExternalCommandState {
+            run: "hostname -s macbook".to_string(),
             sudo: true,
         });
 
@@ -115,7 +111,7 @@ mod tests {
 
         // Verify contents match
         assert_eq!(loaded_snapshot.settings.len(), 3);
-        assert_eq!(loaded_snapshot.external.len(), 2);
+        assert_eq!(loaded_snapshot.commands.len(), 2);
 
         // Convert to HashMap for easier testing
         let settings_map: HashMap<_, _> = loaded_snapshot
@@ -149,17 +145,12 @@ mod tests {
         assert_eq!(global_setting.new_value, "1");
 
         // Check external commands
-        let echo_cmd = &loaded_snapshot.external[0];
-        assert_eq!(echo_cmd.cmd, "echo");
-        assert_eq!(echo_cmd.args, vec!["Hello".to_string()]);
+        let echo_cmd = &loaded_snapshot.commands[0];
+        assert_eq!(echo_cmd.run, "echo Hello");
         assert_eq!(echo_cmd.sudo, false);
 
-        let hostname_cmd = &loaded_snapshot.external[1];
-        assert_eq!(hostname_cmd.cmd, "hostname");
-        assert_eq!(
-            hostname_cmd.args,
-            vec!["-s".to_string(), "macbook".to_string()]
-        );
+        let hostname_cmd = &loaded_snapshot.commands[1];
+        assert_eq!(hostname_cmd.run, "hostname -s macbook");
         assert_eq!(hostname_cmd.sudo, true);
     }
 

--- a/tests/snapshot_test.rs
+++ b/tests/snapshot_test.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod tests {
-    use cutler::snapshot::state::{ExternalCommandState, SettingState, Snapshot, get_snapshot_path};
+    use cutler::snapshot::state::{
+        ExternalCommandState, SettingState, Snapshot, get_snapshot_path,
+    };
     use std::collections::HashMap;
     use std::path::PathBuf;
     use std::{env, fs};

--- a/tests/snapshot_test.rs
+++ b/tests/snapshot_test.rs
@@ -31,7 +31,7 @@ mod tests {
         // Test creation
         let snapshot = Snapshot::new();
         assert_eq!(snapshot.settings.len(), 0);
-        assert_eq!(snapshot.commands.len(), 0);
+        assert_eq!(snapshot.external.len(), 0);
         assert_eq!(snapshot.version, env!("CARGO_PKG_VERSION"));
 
         // Test setting state
@@ -83,12 +83,12 @@ mod tests {
         });
 
         // Add multiple external commands
-        snapshot.commands.push(ExternalCommandState {
+        snapshot.external.push(ExternalCommandState {
             run: "echo Hello".to_string(),
             sudo: false,
         });
 
-        snapshot.commands.push(ExternalCommandState {
+        snapshot.external.push(ExternalCommandState {
             run: "hostname -s macbook".to_string(),
             sudo: true,
         });
@@ -111,7 +111,7 @@ mod tests {
 
         // Verify contents match
         assert_eq!(loaded_snapshot.settings.len(), 3);
-        assert_eq!(loaded_snapshot.commands.len(), 2);
+        assert_eq!(loaded_snapshot.external.len(), 2);
 
         // Convert to HashMap for easier testing
         let settings_map: HashMap<_, _> = loaded_snapshot
@@ -145,11 +145,11 @@ mod tests {
         assert_eq!(global_setting.new_value, "1");
 
         // Check external commands
-        let echo_cmd = &loaded_snapshot.commands[0];
+        let echo_cmd = &loaded_snapshot.external[0];
         assert_eq!(echo_cmd.run, "echo Hello");
         assert_eq!(echo_cmd.sudo, false);
 
-        let hostname_cmd = &loaded_snapshot.commands[1];
+        let hostname_cmd = &loaded_snapshot.external[1];
         assert_eq!(hostname_cmd.run, "hostname -s macbook");
         assert_eq!(hostname_cmd.sudo, true);
     }


### PR DESCRIPTION
## Things changed:

- Removed the `[external]` command in favor of a more simplified architecture with `[commands]` and `[vars]`.
